### PR TITLE
build: implement vcpkg Manifest Mode, CMakePresets and update README

### DIFF
--- a/.github/workflows/agent_ci.yml
+++ b/.github/workflows/agent_ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches: [ "main", "devel" ]
     paths:
-      - 'source/agent/**'      # If changes are in the agent source code
-      - 'libs/**'              # If changes are in libraries (proto, NVIDIA headers)
-      - 'CMakeLists.txt'       # If changes are in main CMake (affects everything)
+      - 'source/agent/**'
+      - 'libs/**'
+      - 'CMakeLists.txt'
+      - 'vcpkg.json'
+      - 'CMakePresets.json'
       - '.github/workflows/agent_ci.yml'
   pull_request:
     branches: [ "main", "devel" ]
@@ -14,6 +16,8 @@ on:
       - 'source/agent/**'
       - 'libs/**'
       - 'CMakeLists.txt'
+      - 'vcpkg.json'
+      - 'CMakePresets.json'
       - '.github/workflows/agent_ci.yml'
 
 jobs:
@@ -21,25 +25,32 @@ jobs:
     name: Build & Format Check
     runs-on: ubuntu-latest
 
+    env:
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
+
+    - name: Install build tools
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake \
-        libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
-        libabsl-dev clang-format cppcheck
+        sudo apt-get install -y build-essential cmake clang-format cppcheck
+
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgJsonGlob: 'vcpkg.json'
 
     - name: Check Code Formatting
       run: |
         find source/agent -name "*.cc" -o -name "*.h" | xargs clang-format --dry-run --Werror -style=Google
 
     - name: CMake Configure
-      run: cmake -B build -S .
+      run: cmake --preset default
 
     - name: Build
-      run: cmake --build build --parallel $(nproc)
+      run: cmake --build --preset default
 
     - name: Analyze Logic
       run: |
@@ -48,5 +59,5 @@ jobs:
         --suppress=missingIncludeSystem \
         --inline-suppr \
         --force \
-        -i build -i libs \
+        -i build \
         source/agent

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,9 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package(Protobuf REQUIRED)
+find_package(protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
 
 set(PROTO_DIR ${CMAKE_SOURCE_DIR}/libs/proto)
 set(PROTO_FILE ${PROTO_DIR}/volta.proto)
@@ -39,7 +40,13 @@ add_library(volta_proto ${PROTO_SRC} ${PROTO_HDR} ${GRPC_SRC} ${GRPC_HDR})
 
 target_include_directories(volta_proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(volta_proto PRIVATE protobuf::libprotobuf gRPC::grpc++)
+target_link_libraries(volta_proto PRIVATE 
+  protobuf::libprotobuf 
+  gRPC::grpc++
+  gRPC::grpc++_reflection
+  fmt::fmt
+  ${CMAKE_DL_LIBS}
+)
 
 include_directories("${LOCAL_INCLUDE_DIR}/nvidia")
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,5 +9,11 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,13 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "default",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
 # volta
+
+
+## Development Setup
+
+Project is using CMake as build system and vcpkg in Manifest Mode for dependency management.
+
+### 1. Initial Requirements
+
+- **Linux** (Kernel 5.x.+)
+- **C++20 Compiler** (GCC 11+/Clang 14+)
+- **CMake** (3.16+)
+- **Git**
+
+### 2. Vcpkg Installation
+
+```bash
+# Clone vcpkg repository
+git clone https://github.com/microsoft/vcpkg.git ~/vcpkg
+
+# Run bootstraping script
+~/vcpkg/bootstrap-vcpkg.sh
+
+# (Optional) Set VCPKG_ROOT environment variable in .bashrc (or other rc)
+# Otherway you will need to enter the path for every single build.
+export VCPKG_ROOT=~/vcpkg
+```
+
+### 3. Build Project
+
+```bash
+# Configurate the project, compile dependencies.
+# If VCPKG_ROOT was not set, point toolchain yourself using
+# -DCMAKE_TOOLCHAIN_FILE=~/vcpkg/scripts/buildsystems/vcpkg.cmake
+cmake -B build -S . 
+
+# Compilation
+cmake --build build
+```
+
+### 4. Run Agent
+
+```bash
+# May require root/admin privileges to access RAPL/Affinity features.
+./build/source/agent/volta_agent
+```
+
+### FAQ 
+**Q: Do I have to enter `vcpkg install`?**
+**A:** No, project is working in Manifest Mode. CMake automatically reads the `vcpkg.json` file and installs whats needed in isolated environment inside build directory.
+
+**Q: I changed `vcpkg.json`, but build see no difference.**
+**A:** Clean up CMake cache, and build project once again:
+```bash
+rm -rf build
+cmake -B build -S .
+```

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "volta-agent",
+  "version-string": "0.1.0",
+  "dependencies": [
+    "fmt",
+    "grpc",
+    "protobuf"
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "volta-agent",
   "version-string": "0.1.0",
+  "builtin-baseline": "6d7bf7ef2193e2d1c5798a5ff8811d533104c861",
   "dependencies": [
     "fmt",
     "grpc",


### PR DESCRIPTION
This PR refactors the project's build system by migrating dependency management from manual vendoring to vcpkg Manifest Mode (vcpkg.json). It also introduces CMakePresets to streamline the configuration process and updates the README.md with a "Development Setup" guide.

The first build will take significantly longer than usual because vcpkg needs to compile deps from source.

**Hot to test**
```bash
# 1. Clean old artifacts
rm -rf build

# 2. Configure project (using the new preset)
# Ensure VCPKG_ROOT is set in your env, or adjust the path in CMakePresets.json
cmake --preset default

# 3. Build
cmake --build build

# 4. Run the agent (verify it starts and loads config)
./build/source/agent/volta_agent
```