### PR TITLE
Feat: Buffer Implementation

### DIFF
--- a/sources/agent/CMakeLists.txt
+++ b/sources/agent/CMakeLists.txt
@@ -62,7 +62,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(volta_agent PRIVATE DEBUG)
 endif()
 
-file(GLOB_RECURSE AGENT_SOURCES "src/*.cc")
+file(GLOB_RECURSE AGENT_SOURCES CONFIGURE_DEPENDS "src/*.cc")
 target_sources(volta_agent PRIVATE ${AGENT_SOURCES})
 
 target_include_directories(volta_agent PRIVATE

--- a/sources/agent/CMakeLists.txt
+++ b/sources/agent/CMakeLists.txt
@@ -77,11 +77,21 @@ target_link_libraries(volta_agent PRIVATE
     tomlplusplus::tomlplusplus
 )
 # --- NVML ---
-find_package(CUDAToolkit QUIET)
+find_path(NVML_INCLUDE_DIR nvml.h
+    PATHS
+        ${CMAKE_SOURCE_DIR}/libs/include/nvidia
+        /usr/include
+        /usr/local/cuda/include
+)
 
-if(CUDAToolkit_FOUND)
-    message(STATUS "Found NVML via CUDAToolkit: ${CUDAToolkit_LIBRARY_DIR}")
-    target_link_libraries(volta_agent PRIVATE CUDA::nvml)
+find_library(NVML_LIBRARY NAMES nvidia-ml nvml
+    PATHS /usr/lib /usr/lib64 /usr/local/lib
+)
+
+if(NVML_INCLUDE_DIR AND NVML_LIBRARY)
+    message(STATUS "Found NVML: ${NVML_LIBRARY}")
+    target_include_directories(volta_agent PRIVATE ${NVML_INCLUDE_DIR})
+    target_link_libraries(volta_agent PRIVATE ${NVML_LIBRARY})
 else()
     message(STATUS "NVML not found - using stub")
     add_library(nvml_stub STATIC ${CMAKE_SOURCE_DIR}/libs/stubs/nvml_stub.cc)

--- a/sources/agent/CMakeLists.txt
+++ b/sources/agent/CMakeLists.txt
@@ -76,23 +76,12 @@ target_link_libraries(volta_agent PRIVATE
     fmt::fmt
     tomlplusplus::tomlplusplus
 )
-
 # --- NVML ---
-find_path(NVML_INCLUDE_DIR nvml.h
-    PATHS
-        ${CMAKE_SOURCE_DIR}/libs/include/nvidia
-        /usr/include
-        /usr/local/cuda/include
-)
+find_package(CUDAToolkit QUIET)
 
-find_library(NVML_LIBRARY NAMES nvidia-ml nvml
-    PATHS /usr/lib /usr/lib64 /usr/local/lib
-)
-
-if(NVML_INCLUDE_DIR AND NVML_LIBRARY)
-    message(STATUS "Found NVML: ${NVML_LIBRARY}")
-    target_include_directories(volta_agent PRIVATE ${NVML_INCLUDE_DIR})
-    target_link_libraries(volta_agent PRIVATE ${NVML_LIBRARY})
+if(CUDAToolkit_FOUND)
+    message(STATUS "Found NVML via CUDAToolkit: ${CUDAToolkit_LIBRARY_DIR}")
+    target_link_libraries(volta_agent PRIVATE CUDA::nvml)
 else()
     message(STATUS "NVML not found - using stub")
     add_library(nvml_stub STATIC ${CMAKE_SOURCE_DIR}/libs/stubs/nvml_stub.cc)

--- a/sources/agent/libs/stubs/nvml_stub.cc
+++ b/sources/agent/libs/stubs/nvml_stub.cc
@@ -78,4 +78,9 @@ nvmlReturn_t nvmlDeviceGetName(nvmlDevice_t device, char* name, unsigned int len
     return NVML_SUCCESS;
 }
 
+nvmlReturn_t nvmlDeviceGetPciInfo_v3(nvmlDevice_t device, nvmlPciInfo_t *pci) {
+    *pci = {0};
+    return nvmlReturn_t::NVML_SUCCESS;
+}
+
 } // extern "C"

--- a/sources/agent/src/buffer.cc
+++ b/sources/agent/src/buffer.cc
@@ -1,7 +1,7 @@
 #include "buffer.h"
 
 #include <cstring>
-#include <functional>
+#include <shared_mutex>
 #include <type_traits>
 #include <variant>
 
@@ -39,70 +39,83 @@ size_t BufferKeyHash::operator()(const BufferKey& key) const noexcept {
   return static_cast<size_t>(hash);
 }
 
-SeriesBuffer::SeriesBuffer(size_t capacity) { SetCapacity(capacity); }
+SeriesBuffer::SeriesBuffer(size_t capacity) : mutex_() {
+  SetCapacity(capacity);
+}
 
 void SeriesBuffer::SetCapacity(size_t capacity) {
   capacity_ = capacity;
   samples_.clear();
   samples_.reserve(capacity_);
+  samples_.resize(capacity_);
   head_ = 0;
   wrapped_ = false;
 }
 
 void SeriesBuffer::Push(const Sample& sample) {
+  std::lock_guard lock(mutex_);
   if (capacity_ == 0) return;
 
-  if (samples_.size() < capacity_) {
-    samples_.push_back(sample);
-    if (samples_.size() == capacity_) {
-      head_ = 0;
-      wrapped_ = true;
-    }
-    return;
-  }
+  if (head_ - tail_ >= capacity_) tail_++;  // drop oldest unsent
 
-  samples_[head_] = sample;
-  head_ = (head_ + 1) % capacity_;
-  wrapped_ = true;
+  samples_[head_ % capacity_] = sample;
+  head_++;
 }
 
 std::optional<Sample> SeriesBuffer::Latest() const {
+  std::lock_guard lock(mutex_);
+
   if (samples_.empty()) return std::nullopt;
-  if (!wrapped_) return samples_.back();
-  const size_t index = (head_ + capacity_ - 1) % capacity_;
-  return samples_[index];
+  return samples_[(head_ - 1) % capacity_];
 }
 
-std::vector<Sample> SeriesBuffer::Snapshot() const {
+SeriesBuffer::Snapshot SeriesBuffer::GetSnapshot() const {
+  std::lock_guard lock(mutex_);
+
   if (samples_.empty()) return {};
-  if (!wrapped_) return samples_;
 
   std::vector<Sample> result;
   result.reserve(samples_.size());
-  for (size_t i = 0; i < samples_.size(); ++i) {
-    const size_t index = (head_ + i) % capacity_;
-    result.push_back(samples_[index]);
+
+  for (size_t i = tail_; i < head_; ++i) {
+    result.push_back(samples_[i % capacity_]);
   }
-  return result;
+
+  return {result, head_};
+}
+
+void SeriesBuffer::AckSnapshot(SeriesBuffer::Snapshot snapshot) {
+  std::lock_guard lock(mutex_);
+
+  if (snapshot.end > tail_) tail_ = snapshot.end;
 }
 
 MetricsBuffer::MetricsBuffer(const config::Config& cfg)
-    : capacity_per_series_(cfg.buffered_time_window / cfg.collection_interval) {
+    : mutex_(),
+      capacity_per_series_(cfg.buffered_time_window / cfg.collection_interval) {
 }
 
 void MetricsBuffer::SetCapacityPerSeries(size_t capacity) {
+  std::lock_guard lock(mutex_);
   capacity_per_series_ = capacity;
   for (auto& [_, buffer] : series_) {
-    buffer.SetCapacity(capacity_per_series_);
+    buffer->SetCapacity(capacity_per_series_);
   }
 }
 
+SeriesBuffer* MetricsBuffer::GetBuffer(const BufferKey& key) {
+  std::shared_lock lock(mutex_);  // read-only, no insertion
+  auto it = series_.find(key);
+  return it != series_.end() ? &*it->second : nullptr;
+}
+
 void MetricsBuffer::AddSample(const BufferKey& key, const Sample& sample) {
-  auto& series = series_[key];
-  if (series.Capacity() != capacity_per_series_) {
-    series.SetCapacity(capacity_per_series_);
+  auto [it, inserted] = series_.emplace(key, nullptr);
+  if (inserted) {
+    it->second = std::make_unique<SeriesBuffer>(capacity_per_series_);
+    keys_.push_back(key);
   }
-  series.Push(sample);
+  it->second->Push(sample);
 }
 
 void MetricsBuffer::AddMetric(const Metric& metric) {
@@ -111,22 +124,36 @@ void MetricsBuffer::AddMetric(const Metric& metric) {
             Sample{.timestamp_ns = metric.timestamp, .value = metric.value});
 }
 
+void MetricsBuffer::AddMetrics(const std::vector<Metric>& metrics) {
+  std::lock_guard lock(mutex_);
+  for (auto metric : metrics) AddMetric(metric);
+}
+
 std::optional<Sample> MetricsBuffer::Latest(const BufferKey& key) const {
+  std::lock_guard lock(mutex_);
+
   auto it = series_.find(key);
   if (it == series_.end()) return std::nullopt;
-  return it->second.Latest();
+  return it->second->Latest();
 }
 
 std::vector<std::pair<BufferKey, Sample>> MetricsBuffer::LatestSamples() const {
+  std::lock_guard lock(mutex_);
+
   std::vector<std::pair<BufferKey, Sample>> result;
   result.reserve(series_.size());
   for (const auto& [key, series] : series_) {
-    auto latest = series.Latest();
+    auto latest = series->Latest();
     if (latest.has_value()) {
       result.emplace_back(key, *latest);
     }
   }
   return result;
+}
+
+std::vector<BufferKey> MetricsBuffer::GetAllKeys() const {
+  std::lock_guard lock(mutex_);
+  return keys_;
 }
 
 BufferKey MetricsBuffer::MakeBufferKey(const Metric& metric) {

--- a/sources/agent/src/buffer.cc
+++ b/sources/agent/src/buffer.cc
@@ -1,0 +1,161 @@
+#include "buffer.h"
+
+#include <cstring>
+#include <functional>
+#include <type_traits>
+#include <variant>
+
+namespace volta {
+namespace agent {
+
+namespace {
+
+constexpr uint64_t kFnvOffset = 1469598103934665603ULL;
+constexpr uint64_t kFnvPrime = 1099511628211ULL;
+
+uint64_t HashCombineBytes(uint64_t hash, const void* data, size_t size) {
+  const auto* bytes = static_cast<const unsigned char*>(data);
+  for (size_t i = 0; i < size; ++i) {
+    hash ^= bytes[i];
+    hash *= kFnvPrime;
+  }
+  return hash;
+}
+
+}  // namespace
+
+size_t BufferKeyHash::operator()(const BufferKey& key) const noexcept {
+  uint64_t hash = kFnvOffset;
+  hash = HashCombineBytes(hash, &key.metric_type, sizeof(key.metric_type));
+  hash = HashCombineBytes(hash, &key.pci_domain, sizeof(key.pci_domain));
+  hash = HashCombineBytes(hash, &key.pci_bus, sizeof(key.pci_bus));
+  hash = HashCombineBytes(hash, &key.pci_device, sizeof(key.pci_device));
+  hash = HashCombineBytes(hash, &key.pci_function, sizeof(key.pci_function));
+  hash = HashCombineBytes(hash, &key.socket_index, sizeof(key.socket_index));
+  hash = HashCombineBytes(hash, &key.core_index, sizeof(key.core_index));
+  hash = HashCombineBytes(hash, &key.ifindex, sizeof(key.ifindex));
+  hash = HashCombineBytes(hash, &key.disk_major, sizeof(key.disk_major));
+  hash = HashCombineBytes(hash, &key.disk_minor, sizeof(key.disk_minor));
+  return static_cast<size_t>(hash);
+}
+
+SeriesBuffer::SeriesBuffer(size_t capacity) { SetCapacity(capacity); }
+
+void SeriesBuffer::SetCapacity(size_t capacity) {
+  capacity_ = capacity;
+  samples_.clear();
+  samples_.reserve(capacity_);
+  head_ = 0;
+  wrapped_ = false;
+}
+
+void SeriesBuffer::Push(const Sample& sample) {
+  if (capacity_ == 0) return;
+
+  if (samples_.size() < capacity_) {
+    samples_.push_back(sample);
+    if (samples_.size() == capacity_) {
+      head_ = 0;
+      wrapped_ = true;
+    }
+    return;
+  }
+
+  samples_[head_] = sample;
+  head_ = (head_ + 1) % capacity_;
+  wrapped_ = true;
+}
+
+std::optional<Sample> SeriesBuffer::Latest() const {
+  if (samples_.empty()) return std::nullopt;
+  if (!wrapped_) return samples_.back();
+  const size_t index = (head_ + capacity_ - 1) % capacity_;
+  return samples_[index];
+}
+
+std::vector<Sample> SeriesBuffer::Snapshot() const {
+  if (samples_.empty()) return {};
+  if (!wrapped_) return samples_;
+
+  std::vector<Sample> result;
+  result.reserve(samples_.size());
+  for (size_t i = 0; i < samples_.size(); ++i) {
+    const size_t index = (head_ + i) % capacity_;
+    result.push_back(samples_[index]);
+  }
+  return result;
+}
+
+MetricsBuffer::MetricsBuffer(size_t capacity_per_series)
+    : capacity_per_series_(capacity_per_series) {}
+
+void MetricsBuffer::SetCapacityPerSeries(size_t capacity) {
+  capacity_per_series_ = capacity;
+  for (auto& [_, buffer] : series_) {
+    buffer.SetCapacity(capacity_per_series_);
+  }
+}
+
+void MetricsBuffer::AddSample(const BufferKey& key, const Sample& sample) {
+  auto& series = series_[key];
+  if (series.Capacity() != capacity_per_series_) {
+    series.SetCapacity(capacity_per_series_);
+  }
+  series.Push(sample);
+}
+
+void MetricsBuffer::AddMetric(const Metric& metric) {
+  if (metric.type == MetricType::METRIC_TYPE_UNSPECIFIED) return;
+  AddSample(MakeBufferKey(metric),
+            Sample{.timestamp_ns = metric.timestamp, .value = metric.value});
+}
+
+std::optional<Sample> MetricsBuffer::Latest(const BufferKey& key) const {
+  auto it = series_.find(key);
+  if (it == series_.end()) return std::nullopt;
+  return it->second.Latest();
+}
+
+std::vector<std::pair<BufferKey, Sample>> MetricsBuffer::LatestSamples() const {
+  std::vector<std::pair<BufferKey, Sample>> result;
+  result.reserve(series_.size());
+  for (const auto& [key, series] : series_) {
+    auto latest = series.Latest();
+    if (latest.has_value()) {
+      result.emplace_back(key, *latest);
+    }
+  }
+  return result;
+}
+
+BufferKey MetricsBuffer::MakeBufferKey(const Metric& metric) {
+  BufferKey key;
+  key.metric_type = static_cast<int32_t>(metric.type);
+  if (!metric.devId.has_value()) return key;
+
+  const auto& device = metric.devId.value();
+  std::visit(
+      [&](const auto& id) {
+        using T = std::decay_t<decltype(id)>;
+        if constexpr (std::is_same_v<T, GpuID>) {
+          key.pci_domain = static_cast<uint16_t>(id.pci_domain());
+          key.pci_bus = static_cast<uint8_t>(id.pci_bus());
+          key.pci_device = static_cast<uint8_t>(id.pci_device());
+          key.pci_function = static_cast<uint8_t>(id.pci_function());
+        } else if constexpr (std::is_same_v<T, CpuID>) {
+          key.socket_index = static_cast<uint8_t>(id.socket_index());
+          key.core_index = static_cast<uint16_t>(id.core_index());
+        } else if constexpr (std::is_same_v<T, NetInterfaceID>) {
+          key.ifindex = id.ifindex();
+        } else if constexpr (std::is_same_v<T, DiskID>) {
+          key.disk_major = id.major();
+          key.disk_minor = id.minor();
+        }
+      },
+      device);
+
+  return key;
+}
+
+}  // namespace agent
+}  // namespace volta

--- a/sources/agent/src/buffer.cc
+++ b/sources/agent/src/buffer.cc
@@ -66,7 +66,7 @@ void SeriesBuffer::Push(const Sample& sample) {
 std::optional<Sample> SeriesBuffer::Latest() const {
   std::lock_guard lock(mutex_);
 
-  if (head_ - tail_ == 0) return std::nullopt;
+  if (head_ == 0) return std::nullopt;
   return samples_[(head_ - 1) % capacity_];
 }
 

--- a/sources/agent/src/buffer.cc
+++ b/sources/agent/src/buffer.cc
@@ -44,12 +44,13 @@ SeriesBuffer::SeriesBuffer(size_t capacity) : mutex_() {
 }
 
 void SeriesBuffer::SetCapacity(size_t capacity) {
+  std::lock_guard lock(mutex_);
+
   capacity_ = capacity;
   samples_.clear();
   samples_.reserve(capacity_);
   samples_.resize(capacity_);
   head_ = 0;
-  wrapped_ = false;
 }
 
 void SeriesBuffer::Push(const Sample& sample) {
@@ -65,7 +66,7 @@ void SeriesBuffer::Push(const Sample& sample) {
 std::optional<Sample> SeriesBuffer::Latest() const {
   std::lock_guard lock(mutex_);
 
-  if (samples_.empty()) return std::nullopt;
+  if (head_ - tail_ == 0) return std::nullopt;
   return samples_[(head_ - 1) % capacity_];
 }
 
@@ -76,10 +77,8 @@ size_t SeriesBuffer::GetNextSnapshotSize() const {
 SeriesBuffer::Snapshot SeriesBuffer::GetSnapshot() const {
   std::shared_lock lock(mutex_);
 
-  if (samples_.empty()) return {};
-
   std::vector<Sample> result;
-  result.reserve(samples_.size());
+  result.reserve(head_ - tail_);
 
   for (size_t i = tail_; i < head_; ++i) {
     result.push_back(samples_[i % capacity_]);
@@ -131,7 +130,7 @@ void MetricsBuffer::AddMetric(const Metric& metric) {
 
 void MetricsBuffer::AddMetrics(const std::vector<Metric>& metrics) {
   std::lock_guard lock(mutex_);
-  for (auto metric : metrics) AddMetric(metric);
+  for (const auto& metric : metrics) AddMetric(metric);
 }
 
 std::optional<Sample> MetricsBuffer::Latest(const BufferKey& key) const {

--- a/sources/agent/src/buffer.cc
+++ b/sources/agent/src/buffer.cc
@@ -69,8 +69,12 @@ std::optional<Sample> SeriesBuffer::Latest() const {
   return samples_[(head_ - 1) % capacity_];
 }
 
+size_t SeriesBuffer::GetNextSnapshotSize() const {
+  std::shared_lock lock(mutex_);
+  return head_ - tail_;
+}
 SeriesBuffer::Snapshot SeriesBuffer::GetSnapshot() const {
-  std::lock_guard lock(mutex_);
+  std::shared_lock lock(mutex_);
 
   if (samples_.empty()) return {};
 
@@ -84,7 +88,7 @@ SeriesBuffer::Snapshot SeriesBuffer::GetSnapshot() const {
   return {result, head_};
 }
 
-void SeriesBuffer::AckSnapshot(SeriesBuffer::Snapshot snapshot) {
+void SeriesBuffer::AckSnapshot(const SeriesBuffer::Snapshot& snapshot) {
   std::lock_guard lock(mutex_);
 
   if (snapshot.end > tail_) tail_ = snapshot.end;
@@ -103,10 +107,11 @@ void MetricsBuffer::SetCapacityPerSeries(size_t capacity) {
   }
 }
 
-SeriesBuffer* MetricsBuffer::GetBuffer(const BufferKey& key) {
-  std::shared_lock lock(mutex_);  // read-only, no insertion
+std::shared_ptr<SeriesBuffer> MetricsBuffer::GetBuffer(
+    const BufferKey& key) const {
+  std::shared_lock lock(mutex_);
   auto it = series_.find(key);
-  return it != series_.end() ? &*it->second : nullptr;
+  return it != series_.end() ? it->second : nullptr;
 }
 
 void MetricsBuffer::AddSample(const BufferKey& key, const Sample& sample) {

--- a/sources/agent/src/buffer.cc
+++ b/sources/agent/src/buffer.cc
@@ -86,8 +86,9 @@ std::vector<Sample> SeriesBuffer::Snapshot() const {
   return result;
 }
 
-MetricsBuffer::MetricsBuffer(size_t capacity_per_series)
-    : capacity_per_series_(capacity_per_series) {}
+MetricsBuffer::MetricsBuffer(const config::Config& cfg)
+    : capacity_per_series_(cfg.buffered_time_window / cfg.collection_interval) {
+}
 
 void MetricsBuffer::SetCapacityPerSeries(size_t capacity) {
   capacity_per_series_ = capacity;

--- a/sources/agent/src/buffer.h
+++ b/sources/agent/src/buffer.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "config/config.h"
 #include "metric.h"
 
 namespace volta {
@@ -70,7 +71,7 @@ static_assert(std::is_standard_layout_v<BufferKey>);
 
 class MetricsBuffer {
  public:
-  explicit MetricsBuffer(size_t capacity_per_series = 0);
+  explicit MetricsBuffer(const config::Config& cfg);
 
   void SetCapacityPerSeries(size_t capacity);
   size_t CapacityPerSeries() const { return capacity_per_series_; }

--- a/sources/agent/src/buffer.h
+++ b/sources/agent/src/buffer.h
@@ -1,16 +1,19 @@
 #ifndef VOLTA_AGENT_SRC_BUFFER_H_
 #define VOLTA_AGENT_SRC_BUFFER_H_
 
+#include <metric.h>
+
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "config/config.h"
-#include "metric.h"
 
 namespace volta {
 namespace agent {
@@ -43,6 +46,8 @@ struct BufferKey {
   bool operator==(const BufferKey&) const = default;
 };
 
+static_assert(std::is_standard_layout_v<BufferKey>);
+
 struct BufferKeyHash {
   size_t operator()(const BufferKey& key) const noexcept;
 };
@@ -51,42 +56,62 @@ class SeriesBuffer {
  public:
   explicit SeriesBuffer(size_t capacity = 0);
 
+  using Snapshot = struct {
+    std::vector<Sample> samples;
+    size_t end;
+  };
+
+  void Push(const Sample& sample);
+  std::optional<Sample> Latest() const;
+
+  // Snapshots all of the unsent data
+  Snapshot GetSnapshot() const;
+
+  // Marks all the samples from the snapshot as sent
+  void AckSnapshot(Snapshot snapshot_end);
+
   void SetCapacity(size_t capacity);
   size_t Capacity() const { return capacity_; }
   size_t Size() const { return samples_.size(); }
   bool Empty() const { return samples_.empty(); }
-
-  void Push(const Sample& sample);
-  std::optional<Sample> Latest() const;
-  std::vector<Sample> Snapshot() const;
+  size_t GetHead() const { return head_; }
+  size_t GetTail() const { return tail_; }
 
  private:
+  mutable std::mutex mutex_;
   size_t capacity_ = 0;
   std::vector<Sample> samples_;
   size_t head_ = 0;
+  size_t tail_ = 0;
   bool wrapped_ = false;
 };
-
-static_assert(std::is_standard_layout_v<BufferKey>);
 
 class MetricsBuffer {
  public:
   explicit MetricsBuffer(const config::Config& cfg);
 
-  void SetCapacityPerSeries(size_t capacity);
   size_t CapacityPerSeries() const { return capacity_per_series_; }
 
+  void AddMetrics(const std::vector<Metric>& metrics);
+  SeriesBuffer* GetBuffer(const BufferKey& key);
+  std::vector<BufferKey> GetAllKeys() const;
+  std::vector<std::pair<BufferKey, Sample>> LatestSamples() const;
+
+  static BufferKey MakeBufferKey(const Metric& metric);
+
+ private:
+  using SeriesMap = std::unordered_map<BufferKey, std::unique_ptr<SeriesBuffer>,
+                                       BufferKeyHash>;
+
+  void SetCapacityPerSeries(size_t capacity);
+  std::optional<Sample> Latest(const BufferKey& key) const;
   void AddSample(const BufferKey& key, const Sample& sample);
   void AddMetric(const Metric& metric);
 
-  std::optional<Sample> Latest(const BufferKey& key) const;
-  std::vector<std::pair<BufferKey, Sample>> LatestSamples() const;
-
- private:
-  static BufferKey MakeBufferKey(const Metric& metric);
-
+  mutable std::shared_mutex mutex_;
   size_t capacity_per_series_ = 0;
-  std::unordered_map<BufferKey, SeriesBuffer, BufferKeyHash> series_;
+  SeriesMap series_;
+  std::vector<BufferKey> keys_;
 };
 
 }  // namespace agent

--- a/sources/agent/src/buffer.h
+++ b/sources/agent/src/buffer.h
@@ -1,0 +1,94 @@
+#ifndef VOLTA_AGENT_SRC_BUFFER_H_
+#define VOLTA_AGENT_SRC_BUFFER_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "metric.h"
+
+namespace volta {
+namespace agent {
+
+struct Sample {
+  int64_t timestamp_ns = 0;
+  double value = 0.0;
+};
+
+struct BufferKey {
+  int32_t metric_type = 0;
+
+  // GPU fields (valid when metric_type in [200, 299])
+  uint16_t pci_domain = 0;
+  uint8_t pci_bus = 0;
+  uint8_t pci_device = 0;
+  uint8_t pci_function = 0;
+
+  // CPU fields (valid when metric_type in [100, 199])
+  uint8_t socket_index = 0;
+  uint16_t core_index = 0;
+
+  // Network fields (valid when metric_type in [500, 599])
+  uint32_t ifindex = 0;
+
+  // Disk fields (valid when metric_type in [400, 499])
+  uint32_t disk_major = 0;
+  uint32_t disk_minor = 0;
+
+  bool operator==(const BufferKey&) const = default;
+};
+
+struct BufferKeyHash {
+  size_t operator()(const BufferKey& key) const noexcept;
+};
+
+class SeriesBuffer {
+ public:
+  explicit SeriesBuffer(size_t capacity = 0);
+
+  void SetCapacity(size_t capacity);
+  size_t Capacity() const { return capacity_; }
+  size_t Size() const { return samples_.size(); }
+  bool Empty() const { return samples_.empty(); }
+
+  void Push(const Sample& sample);
+  std::optional<Sample> Latest() const;
+  std::vector<Sample> Snapshot() const;
+
+ private:
+  size_t capacity_ = 0;
+  std::vector<Sample> samples_;
+  size_t head_ = 0;
+  bool wrapped_ = false;
+};
+
+static_assert(std::is_standard_layout_v<BufferKey>);
+
+class MetricsBuffer {
+ public:
+  explicit MetricsBuffer(size_t capacity_per_series = 0);
+
+  void SetCapacityPerSeries(size_t capacity);
+  size_t CapacityPerSeries() const { return capacity_per_series_; }
+
+  void AddSample(const BufferKey& key, const Sample& sample);
+  void AddMetric(const Metric& metric);
+
+  std::optional<Sample> Latest(const BufferKey& key) const;
+  std::vector<std::pair<BufferKey, Sample>> LatestSamples() const;
+
+ private:
+  static BufferKey MakeBufferKey(const Metric& metric);
+
+  size_t capacity_per_series_ = 0;
+  std::unordered_map<BufferKey, SeriesBuffer, BufferKeyHash> series_;
+};
+
+}  // namespace agent
+}  // namespace volta
+
+#endif  // VOLTA_AGENT_SRC_BUFFER_H_

--- a/sources/agent/src/buffer.h
+++ b/sources/agent/src/buffer.h
@@ -5,7 +5,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <mutex>
 #include <optional>
 #include <shared_mutex>
 #include <type_traits>
@@ -64,8 +63,10 @@ class SeriesBuffer {
   void Push(const Sample& sample);
   std::optional<Sample> Latest() const;
 
+  // Returns the number of unsent samples
   size_t GetNextSnapshotSize() const;
-  // Snapshots all of the unsent data
+
+  // Snapshots all of the unsent samples
   Snapshot GetSnapshot() const;
 
   // Marks all the samples from the snapshot as sent

--- a/sources/agent/src/buffer.h
+++ b/sources/agent/src/buffer.h
@@ -84,7 +84,6 @@ class SeriesBuffer {
   std::vector<Sample> samples_;
   size_t head_ = 0;
   size_t tail_ = 0;
-  bool wrapped_ = false;
 };
 
 class MetricsBuffer {

--- a/sources/agent/src/buffer.h
+++ b/sources/agent/src/buffer.h
@@ -64,11 +64,12 @@ class SeriesBuffer {
   void Push(const Sample& sample);
   std::optional<Sample> Latest() const;
 
+  size_t GetNextSnapshotSize() const;
   // Snapshots all of the unsent data
   Snapshot GetSnapshot() const;
 
   // Marks all the samples from the snapshot as sent
-  void AckSnapshot(Snapshot snapshot_end);
+  void AckSnapshot(const Snapshot& snapshot_end);
 
   void SetCapacity(size_t capacity);
   size_t Capacity() const { return capacity_; }
@@ -78,7 +79,7 @@ class SeriesBuffer {
   size_t GetTail() const { return tail_; }
 
  private:
-  mutable std::mutex mutex_;
+  mutable std::shared_mutex mutex_;
   size_t capacity_ = 0;
   std::vector<Sample> samples_;
   size_t head_ = 0;
@@ -93,14 +94,14 @@ class MetricsBuffer {
   size_t CapacityPerSeries() const { return capacity_per_series_; }
 
   void AddMetrics(const std::vector<Metric>& metrics);
-  SeriesBuffer* GetBuffer(const BufferKey& key);
+  std::shared_ptr<SeriesBuffer> GetBuffer(const BufferKey& key) const;
   std::vector<BufferKey> GetAllKeys() const;
   std::vector<std::pair<BufferKey, Sample>> LatestSamples() const;
 
   static BufferKey MakeBufferKey(const Metric& metric);
 
  private:
-  using SeriesMap = std::unordered_map<BufferKey, std::unique_ptr<SeriesBuffer>,
+  using SeriesMap = std::unordered_map<BufferKey, std::shared_ptr<SeriesBuffer>,
                                        BufferKeyHash>;
 
   void SetCapacityPerSeries(size_t capacity);

--- a/sources/agent/src/collectors/collector.h
+++ b/sources/agent/src/collectors/collector.h
@@ -18,10 +18,9 @@ class Collector {
 
   virtual bool IsSupported() = 0;
 
-  virtual std::vector<v1::MetricType> Satisfiable() = 0;
+  virtual std::vector<MetricType> Satisfiable() = 0;
 
-  virtual void SetRequestedMetrics(
-      const std::vector<v1::MetricType>& metrics) = 0;
+  virtual void SetRequestedMetrics(const std::vector<MetricType>& metrics) = 0;
 
   virtual bool Init() { return true; }
 };
@@ -37,12 +36,12 @@ class CollectorRegistry {
     entries_.push_back(std::move(collector));
   }
 
-  std::vector<Collector*> Resolve(const std::vector<v1::MetricType>& desired) {
+  std::vector<Collector*> Resolve(const std::vector<MetricType>& desired) {
     std::vector<Collector*> result;
     for (auto& collector : entries_) {
       if (!collector->IsSupported()) continue;
 
-      std::vector<v1::MetricType> active;
+      std::vector<MetricType> active;
       for (const auto& type : collector->Satisfiable()) {
         if (std::find(desired.begin(), desired.end(), type) != desired.end()) {
           active.push_back(type);

--- a/sources/agent/src/collectors/nvml_collector.cc
+++ b/sources/agent/src/collectors/nvml_collector.cc
@@ -56,7 +56,7 @@ bool NvmlCollector::IsSupported() {
 }
 
 void NvmlCollector::SetRequestedMetrics(
-    const std::vector<v1::MetricType>& metrics) {
+    const std::vector<MetricType>& metrics) {
   requested_metrics_ = metrics;
 }
 
@@ -67,48 +67,48 @@ std::vector<Metric> NvmlCollector::Collect() {
   unsigned int power_mw = 0;
   auto now = std::chrono::system_clock::now().time_since_epoch().count();
 
-  auto needs = [&](v1::MetricType type) {
+  auto needs = [&](MetricType type) {
     return std::find(requested_metrics_.begin(), requested_metrics_.end(),
                      type) != requested_metrics_.end();
   };
 
   nvmlReturn_t result;
-  if (needs(v1::MetricType::METRIC_TYPE_GPU_POWER)) {
+  if (needs(MetricType::METRIC_TYPE_GPU_POWER)) {
     result = nvmlDeviceGetPowerUsage(device_handle_, &power_mw);
     if (result == NVML_SUCCESS) {
-      metrics.push_back({v1::MetricType::METRIC_TYPE_GPU_POWER,
+      metrics.push_back({MetricType::METRIC_TYPE_GPU_POWER,
                          {.index = 0},
                          static_cast<double>(power_mw) / 1000.0,
                          now});
     }
   }
 
-  if (needs(v1::MetricType::METRIC_TYPE_GPU_TEMPERATURE)) {
+  if (needs(MetricType::METRIC_TYPE_GPU_TEMPERATURE)) {
     unsigned int temp_c = 0;
     result =
         nvmlDeviceGetTemperature(device_handle_, NVML_TEMPERATURE_GPU, &temp_c);
     if (result == NVML_SUCCESS) {
-      metrics.push_back({v1::MetricType::METRIC_TYPE_GPU_TEMPERATURE,
+      metrics.push_back({MetricType::METRIC_TYPE_GPU_TEMPERATURE,
                          {.index = 0},
                          static_cast<double>(temp_c),
                          now});
     }
   }
 
-  if (needs(v1::MetricType::METRIC_TYPE_GPU_UTILIZATION) ||
-      needs(v1::MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION)) {
+  if (needs(MetricType::METRIC_TYPE_GPU_UTILIZATION) ||
+      needs(MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION)) {
     nvmlUtilization_t utilization;
     result = nvmlDeviceGetUtilizationRates(device_handle_, &utilization);
     if (result == NVML_SUCCESS) {
-      if (needs(v1::MetricType::METRIC_TYPE_GPU_UTILIZATION)) {
-        metrics.push_back({v1::MetricType::METRIC_TYPE_GPU_UTILIZATION,
+      if (needs(MetricType::METRIC_TYPE_GPU_UTILIZATION)) {
+        metrics.push_back({MetricType::METRIC_TYPE_GPU_UTILIZATION,
                            {.index = 0},
                            static_cast<double>(utilization.gpu),
                            now});
       }
-      if (needs(v1::MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION)) {
+      if (needs(MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION)) {
         metrics.push_back(
-            {v1::MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION,
+            {MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION,
              {.index = 0},
              static_cast<double>(utilization.memory),
              now});
@@ -116,12 +116,12 @@ std::vector<Metric> NvmlCollector::Collect() {
     }
   }
 
-  if (needs(v1::MetricType::METRIC_TYPE_GPU_VRAM_USED)) {
+  if (needs(MetricType::METRIC_TYPE_GPU_VRAM_USED)) {
     nvmlMemory_t memory;
     result = nvmlDeviceGetMemoryInfo(device_handle_, &memory);
     if (result == NVML_SUCCESS) {
       metrics.push_back(
-          {v1::MetricType::METRIC_TYPE_GPU_VRAM_USED,
+          {MetricType::METRIC_TYPE_GPU_VRAM_USED,
            {.index = 0},
            static_cast<double>(memory.used) / static_cast<double>(memory.total),
            now});
@@ -131,12 +131,12 @@ std::vector<Metric> NvmlCollector::Collect() {
   return metrics;
 }
 
-std::vector<v1::MetricType> NvmlCollector::Satisfiable() {
-  return {v1::MetricType::METRIC_TYPE_GPU_VRAM_USED,
-          v1::MetricType::METRIC_TYPE_GPU_UTILIZATION,
-          v1::MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION,
-          v1::MetricType::METRIC_TYPE_GPU_TEMPERATURE,
-          v1::MetricType::METRIC_TYPE_GPU_POWER};
+std::vector<MetricType> NvmlCollector::Satisfiable() {
+  return {MetricType::METRIC_TYPE_GPU_VRAM_USED,
+          MetricType::METRIC_TYPE_GPU_UTILIZATION,
+          MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION,
+          MetricType::METRIC_TYPE_GPU_TEMPERATURE,
+          MetricType::METRIC_TYPE_GPU_POWER};
 }
 
 }  // namespace collectors

--- a/sources/agent/src/collectors/nvml_collector.cc
+++ b/sources/agent/src/collectors/nvml_collector.cc
@@ -1,5 +1,7 @@
 #include "collectors/nvml_collector.h"
 
+#include <dlfcn.h>
+
 #include <algorithm>
 #include <chrono>
 #include <iostream>
@@ -31,6 +33,22 @@ bool NvmlCollector::Init() {
     nvmlShutdown();
     return false;
   }
+
+  nvmlPciInfo_t pci_info;
+  result = nvmlDeviceGetPciInfo(device_handle_, &pci_info);
+  if (result != NVML_SUCCESS) {
+    std::cerr << "Failed to get PCI info: " << nvmlErrorString(result)
+              << std::endl;
+    nvmlShutdown();
+    return false;
+  }
+
+  GpuID gpu_id;
+  gpu_id.set_pci_domain(pci_info.domain);
+  gpu_id.set_pci_bus(pci_info.bus);
+  gpu_id.set_pci_device(pci_info.device);
+  gpu_id.set_pci_function(0);
+  gpu_id_ = std::move(gpu_id);
 
   initialized_ = true;
   return true;
@@ -76,10 +94,8 @@ std::vector<Metric> NvmlCollector::Collect() {
   if (needs(MetricType::METRIC_TYPE_GPU_POWER)) {
     result = nvmlDeviceGetPowerUsage(device_handle_, &power_mw);
     if (result == NVML_SUCCESS) {
-      metrics.push_back({MetricType::METRIC_TYPE_GPU_POWER,
-                         {.index = 0},
-                         static_cast<double>(power_mw) / 1000.0,
-                         now});
+      metrics.push_back({MetricType::METRIC_TYPE_GPU_POWER, gpu_id_,
+                         static_cast<double>(power_mw) / 1000.0, now});
     }
   }
 
@@ -88,10 +104,8 @@ std::vector<Metric> NvmlCollector::Collect() {
     result =
         nvmlDeviceGetTemperature(device_handle_, NVML_TEMPERATURE_GPU, &temp_c);
     if (result == NVML_SUCCESS) {
-      metrics.push_back({MetricType::METRIC_TYPE_GPU_TEMPERATURE,
-                         {.index = 0},
-                         static_cast<double>(temp_c),
-                         now});
+      metrics.push_back({MetricType::METRIC_TYPE_GPU_TEMPERATURE, gpu_id_,
+                         static_cast<double>(temp_c), now});
     }
   }
 
@@ -101,17 +115,13 @@ std::vector<Metric> NvmlCollector::Collect() {
     result = nvmlDeviceGetUtilizationRates(device_handle_, &utilization);
     if (result == NVML_SUCCESS) {
       if (needs(MetricType::METRIC_TYPE_GPU_UTILIZATION)) {
-        metrics.push_back({MetricType::METRIC_TYPE_GPU_UTILIZATION,
-                           {.index = 0},
-                           static_cast<double>(utilization.gpu),
-                           now});
+        metrics.push_back({MetricType::METRIC_TYPE_GPU_UTILIZATION, gpu_id_,
+                           static_cast<double>(utilization.gpu), now});
       }
       if (needs(MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION)) {
         metrics.push_back(
-            {MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION,
-             {.index = 0},
-             static_cast<double>(utilization.memory),
-             now});
+            {MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION, gpu_id_,
+             static_cast<double>(utilization.memory), now});
       }
     }
   }
@@ -121,8 +131,7 @@ std::vector<Metric> NvmlCollector::Collect() {
     result = nvmlDeviceGetMemoryInfo(device_handle_, &memory);
     if (result == NVML_SUCCESS) {
       metrics.push_back(
-          {MetricType::METRIC_TYPE_GPU_VRAM_USED,
-           {.index = 0},
+          {MetricType::METRIC_TYPE_GPU_VRAM_USED, gpu_id_,
            static_cast<double>(memory.used) / static_cast<double>(memory.total),
            now});
     }

--- a/sources/agent/src/collectors/nvml_collector.h
+++ b/sources/agent/src/collectors/nvml_collector.h
@@ -27,6 +27,7 @@ class NvmlCollector : public RegisteredCollector<NvmlCollector> {
 
  private:
   std::vector<MetricType> requested_metrics_;
+  std::optional<GpuID> gpu_id_;
 
   nvmlDevice_t device_handle_;
   bool initialized_ = false;

--- a/sources/agent/src/collectors/nvml_collector.h
+++ b/sources/agent/src/collectors/nvml_collector.h
@@ -22,11 +22,11 @@ class NvmlCollector : public RegisteredCollector<NvmlCollector> {
   bool Init() override;
   std::vector<Metric> Collect() override;
   bool IsSupported() override;
-  std::vector<v1::MetricType> Satisfiable() override;
-  void SetRequestedMetrics(const std::vector<v1::MetricType>& metrics) override;
+  std::vector<MetricType> Satisfiable() override;
+  void SetRequestedMetrics(const std::vector<MetricType>& metrics) override;
 
  private:
-  std::vector<v1::MetricType> requested_metrics_;
+  std::vector<MetricType> requested_metrics_;
 
   nvmlDevice_t device_handle_;
   bool initialized_ = false;

--- a/sources/agent/src/collectors/proc_stat_collector.cc
+++ b/sources/agent/src/collectors/proc_stat_collector.cc
@@ -12,7 +12,7 @@ namespace collectors {
 bool ProcStatCollector::Init() { return true; }
 
 void ProcStatCollector::SetRequestedMetrics(
-    const std::vector<v1::MetricType>& metrics) {
+    const std::vector<MetricType>& metrics) {
   requested_metrics_ = metrics;
 }
 
@@ -20,7 +20,7 @@ std::vector<Metric> ProcStatCollector::Collect() {
   if (requested_metrics_.empty()) return {};
 
   if (std::find(requested_metrics_.begin(), requested_metrics_.end(),
-                v1::MetricType::METRIC_TYPE_CPU_UTILIZATION) ==
+                MetricType::METRIC_TYPE_CPU_UTILIZATION) ==
       requested_metrics_.end()) {
     return {};
   }
@@ -42,7 +42,7 @@ std::vector<Metric> ProcStatCollector::Collect() {
   prev_idle_ = current_idle;
 
   Metric m;
-  m.type = v1::MetricType::METRIC_TYPE_CPU_UTILIZATION;
+  m.type = MetricType::METRIC_TYPE_CPU_UTILIZATION;
   m.devId = {};
   m.value = usage_percent;
   m.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -56,8 +56,8 @@ bool ProcStatCollector::IsSupported() {
   return std::filesystem::exists("/proc/stat");
 }
 
-std::vector<v1::MetricType> ProcStatCollector::Satisfiable() {
-  return {v1::MetricType::METRIC_TYPE_CPU_UTILIZATION};
+std::vector<MetricType> ProcStatCollector::Satisfiable() {
+  return {MetricType::METRIC_TYPE_CPU_UTILIZATION};
 }
 
 void ProcStatCollector::ReadCpuStats(uint64_t& total, uint64_t& idle) {

--- a/sources/agent/src/collectors/proc_stat_collector.cc
+++ b/sources/agent/src/collectors/proc_stat_collector.cc
@@ -43,7 +43,7 @@ std::vector<Metric> ProcStatCollector::Collect() {
 
   Metric m;
   m.type = MetricType::METRIC_TYPE_CPU_UTILIZATION;
-  m.devId = {};
+  m.devId = std::nullopt;
   m.value = usage_percent;
   m.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::system_clock::now().time_since_epoch())

--- a/sources/agent/src/collectors/proc_stat_collector.h
+++ b/sources/agent/src/collectors/proc_stat_collector.h
@@ -14,13 +14,13 @@ class ProcStatCollector : public RegisteredCollector<ProcStatCollector> {
   bool Init() override;
   std::vector<Metric> Collect() override;
   bool IsSupported() override;
-  std::vector<v1::MetricType> Satisfiable() override;
-  void SetRequestedMetrics(const std::vector<v1::MetricType>& metrics) override;
+  std::vector<MetricType> Satisfiable() override;
+  void SetRequestedMetrics(const std::vector<MetricType>& metrics) override;
 
  private:
   void ReadCpuStats(uint64_t& idle_time, uint64_t& total_time);
 
-  std::vector<v1::MetricType> requested_metrics_;
+  std::vector<MetricType> requested_metrics_;
   uint64_t prev_total_ = 0;
   uint64_t prev_idle_ = 0;
 };

--- a/sources/agent/src/collectors/ram_collector.cc
+++ b/sources/agent/src/collectors/ram_collector.cc
@@ -37,14 +37,12 @@ std::vector<Metric> RamCollector::Collect() {
   auto now = std::chrono::system_clock::now().time_since_epoch().count();
   std::vector<Metric> metrics;
   if (needs_total) {
-    metrics.push_back({MetricType::METRIC_TYPE_RAM_TOTAL,
-                       {.name = "ram"},
-                       (double)total,
-                       now});
+    metrics.push_back(
+        {MetricType::METRIC_TYPE_RAM_TOTAL, std::nullopt, (double)total, now});
   }
   if (needs_used) {
     metrics.push_back(
-        {MetricType::METRIC_TYPE_RAM_USED, {.name = "ram"}, (double)used, now});
+        {MetricType::METRIC_TYPE_RAM_USED, std::nullopt, (double)used, now});
   }
   return metrics;
 }

--- a/sources/agent/src/collectors/ram_collector.cc
+++ b/sources/agent/src/collectors/ram_collector.cc
@@ -15,8 +15,7 @@ bool RamCollector::Init() {
   return true;
 }
 
-void RamCollector::SetRequestedMetrics(
-    const std::vector<v1::MetricType>& metrics) {
+void RamCollector::SetRequestedMetrics(const std::vector<MetricType>& metrics) {
   requested_metrics_ = metrics;
 }
 
@@ -25,12 +24,10 @@ std::vector<Metric> RamCollector::Collect() {
 
   bool needs_total =
       std::find(requested_metrics_.begin(), requested_metrics_.end(),
-                v1::MetricType::METRIC_TYPE_RAM_TOTAL) !=
-      requested_metrics_.end();
+                MetricType::METRIC_TYPE_RAM_TOTAL) != requested_metrics_.end();
   bool needs_used =
       std::find(requested_metrics_.begin(), requested_metrics_.end(),
-                v1::MetricType::METRIC_TYPE_RAM_USED) !=
-      requested_metrics_.end();
+                MetricType::METRIC_TYPE_RAM_USED) != requested_metrics_.end();
   if (!needs_total && !needs_used) return {};
 
   uint64_t used = 0;
@@ -40,23 +37,20 @@ std::vector<Metric> RamCollector::Collect() {
   auto now = std::chrono::system_clock::now().time_since_epoch().count();
   std::vector<Metric> metrics;
   if (needs_total) {
-    metrics.push_back({v1::MetricType::METRIC_TYPE_RAM_TOTAL,
+    metrics.push_back({MetricType::METRIC_TYPE_RAM_TOTAL,
                        {.name = "ram"},
                        (double)total,
                        now});
   }
   if (needs_used) {
-    metrics.push_back({v1::MetricType::METRIC_TYPE_RAM_USED,
-                       {.name = "ram"},
-                       (double)used,
-                       now});
+    metrics.push_back(
+        {MetricType::METRIC_TYPE_RAM_USED, {.name = "ram"}, (double)used, now});
   }
   return metrics;
 }
 
-std::vector<v1::MetricType> RamCollector::Satisfiable() {
-  return {v1::MetricType::METRIC_TYPE_RAM_TOTAL,
-          v1::MetricType::METRIC_TYPE_RAM_USED};
+std::vector<MetricType> RamCollector::Satisfiable() {
+  return {MetricType::METRIC_TYPE_RAM_TOTAL, MetricType::METRIC_TYPE_RAM_USED};
 }
 
 void RamCollector::ReadStats(uint64_t& used, uint64_t& total) {

--- a/sources/agent/src/collectors/ram_collector.h
+++ b/sources/agent/src/collectors/ram_collector.h
@@ -12,13 +12,13 @@ class RamCollector : public RegisteredCollector<RamCollector> {
   bool Init() override;
   std::vector<Metric> Collect() override;
   bool IsSupported() override;
-  std::vector<v1::MetricType> Satisfiable() override;
-  void SetRequestedMetrics(const std::vector<v1::MetricType>& metrics) override;
+  std::vector<MetricType> Satisfiable() override;
+  void SetRequestedMetrics(const std::vector<MetricType>& metrics) override;
 
  private:
   void ReadStats(uint64_t& used, uint64_t& total);
 
-  std::vector<v1::MetricType> requested_metrics_;
+  std::vector<MetricType> requested_metrics_;
   bool initialized_ = false;
 };
 

--- a/sources/agent/src/collectors/rapl_collector.cc
+++ b/sources/agent/src/collectors/rapl_collector.cc
@@ -76,7 +76,10 @@ std::vector<Metric> RaplCollector::Collect() {
   double value = energy_units_ * readout;
   Metric m;
   m.type = MetricType::METRIC_TYPE_CPU_POWER_PACKAGE;
-  m.devId = {};
+  CpuID cpu_id;
+  cpu_id.set_socket_index(0);
+  cpu_id.set_core_index(0);
+  m.devId = DeviceId{std::move(cpu_id)};
   m.value = value - last_value;
   m.timestamp = std::chrono::system_clock::now().time_since_epoch().count();
   last_value = value;

--- a/sources/agent/src/collectors/rapl_collector.cc
+++ b/sources/agent/src/collectors/rapl_collector.cc
@@ -54,14 +54,14 @@ bool RaplCollector::IsSupported() {
 }
 
 void RaplCollector::SetRequestedMetrics(
-    const std::vector<v1::MetricType>& metrics) {
+    const std::vector<MetricType>& metrics) {
   requested_metrics_ = metrics;
 }
 
 std::vector<Metric> RaplCollector::Collect() {
   if (!initialized_ || requested_metrics_.empty()) return {};
   if (std::find(requested_metrics_.begin(), requested_metrics_.end(),
-                v1::MetricType::METRIC_TYPE_CPU_POWER_PACKAGE) ==
+                MetricType::METRIC_TYPE_CPU_POWER_PACKAGE) ==
       requested_metrics_.end()) {
     return {};
   }
@@ -75,7 +75,7 @@ std::vector<Metric> RaplCollector::Collect() {
 
   double value = energy_units_ * readout;
   Metric m;
-  m.type = v1::MetricType::METRIC_TYPE_CPU_POWER_PACKAGE;
+  m.type = MetricType::METRIC_TYPE_CPU_POWER_PACKAGE;
   m.devId = {};
   m.value = value - last_value;
   m.timestamp = std::chrono::system_clock::now().time_since_epoch().count();
@@ -83,8 +83,8 @@ std::vector<Metric> RaplCollector::Collect() {
   return {m};
 }
 
-std::vector<v1::MetricType> RaplCollector::Satisfiable() {
-  return {v1::MetricType::METRIC_TYPE_CPU_POWER_PACKAGE};
+std::vector<MetricType> RaplCollector::Satisfiable() {
+  return {MetricType::METRIC_TYPE_CPU_POWER_PACKAGE};
 }
 
 uint64_t RaplCollector::ReadMSR(uint8_t core, uint32_t offset) {

--- a/sources/agent/src/collectors/rapl_collector.h
+++ b/sources/agent/src/collectors/rapl_collector.h
@@ -15,15 +15,15 @@ class RaplCollector : public RegisteredCollector<RaplCollector> {
   bool Init() override;
   std::vector<Metric> Collect() override;
   bool IsSupported() override;
-  std::vector<v1::MetricType> Satisfiable() override;
-  void SetRequestedMetrics(const std::vector<v1::MetricType>& metrics) override;
+  std::vector<MetricType> Satisfiable() override;
+  void SetRequestedMetrics(const std::vector<MetricType>& metrics) override;
   ~RaplCollector();
 
  private:
   uint64_t ReadMSR(uint8_t core, uint32_t offset);
   void OpenMSR();
   void CloseMSR(int fd);
-  std::vector<v1::MetricType> requested_metrics_;
+  std::vector<MetricType> requested_metrics_;
   bool initialized_ = false;
   double power_units_ = 0, energy_units_ = 0, time_units_ = 0;
   std::vector<int> MSR_files_;

--- a/sources/agent/src/config/config.h
+++ b/sources/agent/src/config/config.h
@@ -58,7 +58,7 @@ struct Config {
   cpu_set_t core_affinity = kDefaultAffinity;
   std::string server_address = kDefaultServerAddress;
   uint16_t server_port = kDefaultServerPort;
-  std::vector<v1::MetricType> requestedMetrics;
+  std::vector<MetricType> requestedMetrics;
 };
 
 }  // namespace config

--- a/sources/agent/src/config/config.h
+++ b/sources/agent/src/config/config.h
@@ -37,6 +37,7 @@ struct Config {
   // TODO: move this initialization logic to the ConfigLoader's
   // LoadDefaultConfig method
   static constexpr int32_t kDefaultIntervalMs = 500;
+  static constexpr int32_t kDefaultTimeWindowMs = 2000;
   static constexpr char const* kDefaultServerAddress = "localhost";
   static constexpr uint16_t kDefaultServerPort = 50051;
   static inline cpu_set_t kDefaultAffinity = [] {
@@ -59,6 +60,8 @@ struct Config {
   std::string server_address = kDefaultServerAddress;
   uint16_t server_port = kDefaultServerPort;
   std::vector<MetricType> requestedMetrics;
+  std::chrono::milliseconds buffered_time_window =
+      std::chrono::milliseconds(kDefaultTimeWindowMs);
 };
 
 }  // namespace config

--- a/sources/agent/src/config/config_loader.cc
+++ b/sources/agent/src/config/config_loader.cc
@@ -12,9 +12,6 @@
 
 #include "utils/utils.h"
 
-namespace utils = volta::agent::utils;
-namespace v1 = volta::v1;
-
 namespace volta {
 namespace agent {
 namespace config {
@@ -39,41 +36,41 @@ Config ConfigLoader::LoadDefaultConfig() {
 
   // request all metrics by default for now
   config.requestedMetrics = {
-      v1::MetricType::METRIC_TYPE_UNSPECIFIED,
-      v1::MetricType::METRIC_TYPE_CPU_POWER_PACKAGE,
-      v1::MetricType::METRIC_TYPE_CPU_POWER_CORES,
-      v1::MetricType::METRIC_TYPE_CPU_CLOCK_SPEED,
-      v1::MetricType::METRIC_TYPE_CPU_UTILIZATION,
-      v1::MetricType::METRIC_TYPE_CPU_TEMPERATURE,
-      v1::MetricType::METRIC_TYPE_CPU_IOWAIT,
-      v1::MetricType::METRIC_TYPE_CPU_CACHE_HIT_RATIO,
-      v1::MetricType::METRIC_TYPE_CPU_ACTIVE_PROCESSES,
-      v1::MetricType::METRIC_TYPE_GPU_POWER,
-      v1::MetricType::METRIC_TYPE_GPU_CLOCK_SPEED,
-      v1::MetricType::METRIC_TYPE_GPU_UTILIZATION,
-      v1::MetricType::METRIC_TYPE_GPU_TEMPERATURE,
-      v1::MetricType::METRIC_TYPE_GPU_VRAM_USED,
-      v1::MetricType::METRIC_TYPE_GPU_PCIE_BANDWIDTH,
-      v1::MetricType::METRIC_TYPE_GPU_COMPUTE_UNIT_UTILIZATION,
-      v1::MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION,
-      v1::MetricType::METRIC_TYPE_GPU_REGISTER_UTILIZATION,
-      v1::MetricType::METRIC_TYPE_RAM_POWER,
-      v1::MetricType::METRIC_TYPE_RAM_TOTAL,
-      v1::MetricType::METRIC_TYPE_RAM_AVAILABLE,
-      v1::MetricType::METRIC_TYPE_RAM_USED,
-      v1::MetricType::METRIC_TYPE_RAM_CACHED,
-      v1::MetricType::METRIC_TYPE_SWAP_USED,
-      v1::MetricType::METRIC_TYPE_SWAP_ACTIVITY,
-      v1::MetricType::METRIC_TYPE_DISK_READ_THROUGHPUT,
-      v1::MetricType::METRIC_TYPE_DISK_WRITE_THROUGHPUT,
-      v1::MetricType::METRIC_TYPE_DISK_READ_IOPS,
-      v1::MetricType::METRIC_TYPE_DISK_WRITE_IOPS,
-      v1::MetricType::METRIC_TYPE_DISK_BUSY_TIME,
-      v1::MetricType::METRIC_TYPE_DISK_CAPACITY_USED,
-      v1::MetricType::METRIC_TYPE_NET_BYTES_RECEIVED,
-      v1::MetricType::METRIC_TYPE_NET_BYTES_SENT,
-      v1::MetricType::METRIC_TYPE_NET_PACKETS_RECEIVED,
-      v1::MetricType::METRIC_TYPE_NET_PACKETS_SENT,
+      MetricType::METRIC_TYPE_UNSPECIFIED,
+      MetricType::METRIC_TYPE_CPU_POWER_PACKAGE,
+      MetricType::METRIC_TYPE_CPU_POWER_CORES,
+      MetricType::METRIC_TYPE_CPU_CLOCK_SPEED,
+      MetricType::METRIC_TYPE_CPU_UTILIZATION,
+      MetricType::METRIC_TYPE_CPU_TEMPERATURE,
+      MetricType::METRIC_TYPE_CPU_IOWAIT,
+      MetricType::METRIC_TYPE_CPU_CACHE_HIT_RATIO,
+      MetricType::METRIC_TYPE_CPU_ACTIVE_PROCESSES,
+      MetricType::METRIC_TYPE_GPU_POWER,
+      MetricType::METRIC_TYPE_GPU_CLOCK_SPEED,
+      MetricType::METRIC_TYPE_GPU_UTILIZATION,
+      MetricType::METRIC_TYPE_GPU_TEMPERATURE,
+      MetricType::METRIC_TYPE_GPU_VRAM_USED,
+      MetricType::METRIC_TYPE_GPU_PCIE_BANDWIDTH,
+      MetricType::METRIC_TYPE_GPU_COMPUTE_UNIT_UTILIZATION,
+      MetricType::METRIC_TYPE_GPU_SHARED_MEMORY_UTILIZATION,
+      MetricType::METRIC_TYPE_GPU_REGISTER_UTILIZATION,
+      MetricType::METRIC_TYPE_RAM_POWER,
+      MetricType::METRIC_TYPE_RAM_TOTAL,
+      MetricType::METRIC_TYPE_RAM_AVAILABLE,
+      MetricType::METRIC_TYPE_RAM_USED,
+      MetricType::METRIC_TYPE_RAM_CACHED,
+      MetricType::METRIC_TYPE_SWAP_USED,
+      MetricType::METRIC_TYPE_SWAP_ACTIVITY,
+      MetricType::METRIC_TYPE_DISK_READ_THROUGHPUT,
+      MetricType::METRIC_TYPE_DISK_WRITE_THROUGHPUT,
+      MetricType::METRIC_TYPE_DISK_READ_IOPS,
+      MetricType::METRIC_TYPE_DISK_WRITE_IOPS,
+      MetricType::METRIC_TYPE_DISK_BUSY_TIME,
+      MetricType::METRIC_TYPE_DISK_CAPACITY_USED,
+      MetricType::METRIC_TYPE_NET_BYTES_RECEIVED,
+      MetricType::METRIC_TYPE_NET_BYTES_SENT,
+      MetricType::METRIC_TYPE_NET_PACKETS_RECEIVED,
+      MetricType::METRIC_TYPE_NET_PACKETS_SENT,
   };
 
   return config;
@@ -252,10 +249,10 @@ void ConfigLoader::LoadMetrics(toml::table& tbl, Config& out_config) {
 
   auto metrics_node = tbl["metrics"];
 
-  std::vector<v1::MetricType> metrics;
+  std::vector<MetricType> metrics;
 
-  auto append_metric = [&](v1::MetricType metric) {
-    if (metric == v1::MetricType::METRIC_TYPE_UNSPECIFIED) {
+  auto append_metric = [&](MetricType metric) {
+    if (metric == MetricType::METRIC_TYPE_UNSPECIFIED) {
       return;
     }
     if (std::find(metrics.begin(), metrics.end(), metric) == metrics.end()) {
@@ -264,9 +261,9 @@ void ConfigLoader::LoadMetrics(toml::table& tbl, Config& out_config) {
   };
 
   auto parse_metric_name = [&](const std::string& name,
-                               v1::MetricType& metric) -> bool {
-    if (v1::MetricType_Parse(name, &metric)) return true;
-    if (v1::MetricType_Parse(std::string("METRIC_TYPE_") + name, &metric))
+                               MetricType& metric) -> bool {
+    if (MetricType_Parse(name, &metric)) return true;
+    if (MetricType_Parse(std::string("METRIC_TYPE_") + name, &metric))
       return true;
     return false;
   };
@@ -274,16 +271,16 @@ void ConfigLoader::LoadMetrics(toml::table& tbl, Config& out_config) {
   if (auto arr = metrics_node.as_array()) {
     for (const auto& item : *arr) {
       if (auto metric_num = item.value<int>()) {
-        if (!v1::MetricType_IsValid(*metric_num)) {
+        if (!MetricType_IsValid(*metric_num)) {
           std::cerr << "Invalid metric value: " << *metric_num << std::endl;
           continue;
         }
-        append_metric(static_cast<v1::MetricType>(*metric_num));
+        append_metric(static_cast<MetricType>(*metric_num));
         continue;
       }
 
       if (auto metric_name = item.value<std::string>()) {
-        v1::MetricType metric;
+        MetricType metric;
         if (!parse_metric_name(*metric_name, metric)) {
           std::cerr << "Invalid metric name: " << *metric_name << std::endl;
           continue;
@@ -295,7 +292,7 @@ void ConfigLoader::LoadMetrics(toml::table& tbl, Config& out_config) {
       std::cerr << "Invalid metric entry type" << std::endl;
     }
   } else if (auto val = metrics_node.value<std::string>()) {
-    v1::MetricType metric;
+    MetricType metric;
     if (parse_metric_name(*val, metric)) {
       append_metric(metric);
     } else {

--- a/sources/agent/src/config/config_loader.cc
+++ b/sources/agent/src/config/config_loader.cc
@@ -21,7 +21,8 @@ std::filesystem::path ConfigLoader::kConfigFile = "agent.conf";
 std::filesystem::path ConfigLoader::kUUIDFile = "agent.uuid";
 
 std::set<std::string_view, std::less<>> ConfigLoader::kValidTopLevelKeys = {
-    "core_affinity", "interval", "server_address", "server_port", "metrics"};
+    "core_affinity", "interval", "server_address",
+    "server_port",   "metrics",  "time_window"};
 
 Config ConfigLoader::LoadConfig() {
   Config config = LoadDefaultConfig();
@@ -107,6 +108,7 @@ void ConfigLoader::LoadConfigFile(Config& out_config) {
 
     LoadCoreAffinity(tbl, out_config);
     LoadInterval(tbl, out_config);
+    LoadTimeWindow(tbl, out_config);
     LoadServerAddress(tbl, out_config);
     LoadServerPort(tbl, out_config);
     LoadMetrics(tbl, out_config);
@@ -308,6 +310,27 @@ void ConfigLoader::LoadMetrics(toml::table& tbl, Config& out_config) {
     out_config.requestedMetrics = std::move(metrics);
     std::cout << "Requested metrics updated to "
               << out_config.requestedMetrics.size() << " entries" << std::endl;
+  }
+}
+
+void ConfigLoader::LoadTimeWindow(toml::table& tbl, Config& out_config) {
+  if (!tbl.contains("time_window")) {
+    return;
+  }
+
+  auto val = tbl["time_window"];
+
+  if (auto window = val.value<float>();
+      window &&
+      (*window * 1000) > (float)out_config.collection_interval.count()) {
+    out_config.buffered_time_window =
+        std::chrono::milliseconds((uint32_t)(*window * 1000));
+    std::cout << "Time window set to " << *window << std::endl;
+  } else {
+    std::cerr << "time_window has an incorrect type or value, use number "
+                 "larger than collection interval ("
+              << (float_t)out_config.collection_interval.count() / 1000.0
+              << "s)" << std::endl;
   }
 }
 

--- a/sources/agent/src/config/config_loader.h
+++ b/sources/agent/src/config/config_loader.h
@@ -28,6 +28,7 @@ class ConfigLoader {
   static void LoadServerAddress(toml::table& tbl, Config& out_config);
   static void LoadServerPort(toml::table& tbl, Config& out_config);
   static void LoadMetrics(toml::table& tbl, Config& out_config);
+  static void LoadTimeWindow(toml::table& tbl, Config& out_config);
   static void CheckKeys(toml::table& tbl);
 
   static std::filesystem::path kConfigFile;

--- a/sources/agent/src/metric.h
+++ b/sources/agent/src/metric.h
@@ -19,7 +19,7 @@ struct DeviceId {
 };
 
 struct Metric {
-  v1::MetricType type;
+  MetricType type;
   DeviceId devId;
   double value;
   int64_t timestamp;

--- a/sources/agent/src/metric.h
+++ b/sources/agent/src/metric.h
@@ -3,26 +3,22 @@
 
 #include <cstdint>
 #include <optional>
-#include <string>
+#include <variant>
 
 #include "volta.pb.h"
 
 namespace volta {
 namespace agent {
 
-struct DeviceId {
-  std::optional<std::string>
-      uuid;  // device UUID from NVML/ROCm, disk serial, etc.
-  std::optional<std::string> name;  // Human-readable: "sda", "eth0", "GPU 0"
-  std::optional<uint32_t> index;    // 0-based index (GPU slot, CPU core, etc.)
-  std::optional<std::string> vendor;  // "nvidia" | "amd" | "intel"
-};
+using DeviceId = std::variant<GpuID, CpuID, NetInterfaceID, DiskID>;
 
 struct Metric {
-  MetricType type;
-  DeviceId devId;
-  double value;
-  int64_t timestamp;
+  MetricType type = MetricType::METRIC_TYPE_UNSPECIFIED;
+  std::optional<DeviceId> devId;
+  double value = 0.0;
+  int64_t timestamp = 0;
+
+  bool HasDevice() const { return devId.has_value(); }
 };
 
 }  // namespace agent

--- a/sources/agent/src/scheduler.cc
+++ b/sources/agent/src/scheduler.cc
@@ -44,7 +44,7 @@ void Scheduler::PrintDashboard(const std::vector<Metric>& metrics) {
   std::cout << "-----------------------------------------------\n";
 
   for (const auto& m : metrics) {
-    std::cout << std::left << std::setw(30) << v1::MetricType_Name(m.type)
+    std::cout << std::left << std::setw(30) << MetricType_Name(m.type)
               << std::fixed << std::setprecision(2) << m.value << "\n";
   }
 

--- a/sources/agent/src/scheduler.cc
+++ b/sources/agent/src/scheduler.cc
@@ -10,7 +10,7 @@ namespace agent {
 
 Scheduler::Scheduler(const config::Config& config,
                      std::vector<collectors::Collector*>&& collectors)
-    : collectors_(std::move(collectors)), config_(config), buffer_(1) {}
+    : collectors_(std::move(collectors)), config_(config), buffer_(config) {}
 
 void Scheduler::Run() {
   for (auto collector : collectors_) {
@@ -60,8 +60,10 @@ void Scheduler::PrintDashboard() {
   std::cout << "    VOLTA AGENT v0.5 - ACTIVE MONITOR    \n";
   std::cout << "===============================================\n";
 
-  std::cout << std::left << std::setw(42) << "METRIC NAME"
-            << "    VALUE\n";
+  std::cout << std::left << std::setw(42) << "METRIC NAME" << std::setw(38)
+            << "DEVICE"
+            << "    " << std::fixed << "VALUE"
+            << "\n";
   std::cout << "-----------------------------------------------\n";
 
   auto latest = buffer_.LatestSamples();
@@ -81,6 +83,7 @@ void Scheduler::PrintDashboard() {
 
   std::cout << "-----------------------------------------------\n";
   std::cout << "Data points collected: " << latest.size() << "\n";
+  std::cout << "# of metrics buffered: " << buffer_.CapacityPerSeries() << "\n";
   std::cout << "Press Ctrl+C to exit."
             << "\n";
   std::cout.flush();

--- a/sources/agent/src/scheduler.cc
+++ b/sources/agent/src/scheduler.cc
@@ -2,6 +2,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <thread>
 
 namespace volta {
@@ -9,7 +10,7 @@ namespace agent {
 
 Scheduler::Scheduler(const config::Config& config,
                      std::vector<collectors::Collector*>&& collectors)
-    : config_(config), collectors_(std::move(collectors)) {}
+    : collectors_(std::move(collectors)), config_(config), buffer_(1) {}
 
 void Scheduler::Run() {
   for (auto collector : collectors_) {
@@ -19,37 +20,67 @@ void Scheduler::Run() {
             << config_.collection_interval.count() << "ms)..." << std::endl;
 
   while (true) {
-    std::vector<Metric> batch;
     for (const auto& collector : collectors_) {
       auto metrics = collector->Collect();
-      batch.insert(batch.end(), metrics.begin(), metrics.end());
+      for (const auto& metric : metrics) {
+        buffer_.AddMetric(metric);
+      }
     }
 
-    PrintDashboard(batch);
+    PrintDashboard();
 
     std::this_thread::sleep_for(config_.collection_interval);
   }
 }
 
-void Scheduler::PrintDashboard(const std::vector<Metric>& metrics) {
+std::string Scheduler::DescribeKey(const BufferKey& key) {
+  std::ostringstream out;
+  if (key.pci_domain || key.pci_bus || key.pci_device || key.pci_function) {
+    out << "gpu=" << key.pci_domain << ':' << static_cast<int>(key.pci_bus)
+        << ':' << static_cast<int>(key.pci_device) << '.'
+        << static_cast<int>(key.pci_function);
+  } else if (key.socket_index || key.core_index) {
+    out << "cpu=" << static_cast<int>(key.socket_index) << "/"
+        << key.core_index;
+  } else if (key.ifindex) {
+    out << "net_ifindex=" << key.ifindex;
+  } else if (key.disk_major || key.disk_minor) {
+    out << "disk=" << key.disk_major << ':' << key.disk_minor;
+  } else {
+    out << "system";
+  }
+  return out.str();
+}
+
+void Scheduler::PrintDashboard() {
   // ansi clean screen, move cursor to top-left
   std::cout << "\033[2J\033[1;1H";
 
   std::cout << "===============================================\n";
-  std::cout << "    VOLTA AGENT v0.1 (POC) - ACTIVE MONITOR    \n";
+  std::cout << "    VOLTA AGENT v0.5 - ACTIVE MONITOR    \n";
   std::cout << "===============================================\n";
 
-  std::cout << std::left << std::setw(30) << "METRIC NAME"
-            << "VALUE\n";
+  std::cout << std::left << std::setw(42) << "METRIC NAME"
+            << "    VALUE\n";
   std::cout << "-----------------------------------------------\n";
 
-  for (const auto& m : metrics) {
-    std::cout << std::left << std::setw(30) << MetricType_Name(m.type)
-              << std::fixed << std::setprecision(2) << m.value << "\n";
+  auto latest = buffer_.LatestSamples();
+  for (const auto& [key, sample] : latest) {
+    auto metric_name =
+        MetricType_Name(static_cast<MetricType>(key.metric_type));
+    const std::string prefix = "METRIC_TYPE_";
+    if (metric_name.rfind(prefix, 0) == 0) {
+      metric_name = metric_name.substr(prefix.size());
+    }
+
+    std::cout << std::left << std::setw(42) << metric_name << std::setw(38)
+              << DescribeKey(key) << "    " << std::fixed
+              << std::setprecision(2) << sample.value << " @ "
+              << sample.timestamp_ns << "\n";
   }
 
   std::cout << "-----------------------------------------------\n";
-  std::cout << "Data points collected: " << metrics.size() << "\n";
+  std::cout << "Data points collected: " << latest.size() << "\n";
   std::cout << "Press Ctrl+C to exit."
             << "\n";
   std::cout.flush();

--- a/sources/agent/src/scheduler.cc
+++ b/sources/agent/src/scheduler.cc
@@ -21,10 +21,10 @@ void Scheduler::Run() {
 
   while (true) {
     for (const auto& collector : collectors_) {
+      // TODO: make the metrics collect into a preallocated tray
+      //       instead of allocating new memory for each collection
       auto metrics = collector->Collect();
-      for (const auto& metric : metrics) {
-        buffer_.AddMetric(metric);
-      }
+      buffer_.AddMetrics(metrics);
     }
 
     PrintDashboard();

--- a/sources/agent/src/scheduler.h
+++ b/sources/agent/src/scheduler.h
@@ -2,8 +2,10 @@
 #define VOLTA_AGENT_SRC_SCHEDULER_H_
 
 #include <memory>
+#include <string>
 #include <vector>
 
+#include "buffer.h"
 #include "collectors/collector.h"
 #include "config/config.h"
 #include "metric.h"
@@ -19,10 +21,12 @@ class Scheduler {
   void Run();
 
  private:
-  void PrintDashboard(const std::vector<Metric>& metrics);
+  void PrintDashboard();
+  static std::string DescribeKey(const BufferKey& key);
 
   std::vector<collectors::Collector*> collectors_;
   const config::Config& config_;
+  MetricsBuffer buffer_;
 };
 
 }  // namespace agent

--- a/sources/proto/volta.proto
+++ b/sources/proto/volta.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 
-package volta.v1;
+package volta;
 
 
 enum MetricType {
@@ -52,6 +52,7 @@ enum MetricType {
   METRIC_TYPE_NET_PACKETS_RECEIVED = 502;
   METRIC_TYPE_NET_PACKETS_SENT = 503;
 }
+
 
 service VoltaCollector {
   rpc CollectMetrics(stream MetricBatch) returns (CollectResponse);

--- a/sources/proto/volta.proto
+++ b/sources/proto/volta.proto
@@ -54,16 +54,45 @@ enum MetricType {
 }
 
 
-service VoltaCollector {
-  rpc CollectMetrics(stream MetricBatch) returns (CollectResponse);
+message GpuID {
+  uint32 pci_domain = 1;
+  uint32 pci_bus = 2;
+  uint32 pci_device = 3;
+  uint32 pci_function = 4;
 }
 
-message MetricBatch {
-  google.protobuf.Timestamp timestamp = 1;
+message CpuID {
+  uint32 socket_index = 1;
+  uint32 core_index = 2;
+}
 
-  string hostname = 2;
+message NetInterfaceID {
+  uint32 ifindex = 1;
+}
 
-  map<string, double> metrics = 3;
+message DiskID {
+  uint32 major = 1;
+  uint32 minor = 2;
+}
+
+message DeviceID {
+  oneof device {
+    GpuID gpu = 1;
+    CpuID cpu = 2;
+    NetInterfaceID network = 3;
+    DiskID disk = 4;
+  }
+}
+
+message MetricObservation {
+  MetricType metric_type = 1;
+  DeviceID device_id = 2;
+  google.protobuf.Timestamp timestamp = 3;
+  double value = 4;
+}
+
+service VoltaCollector {
+  rpc CollectMetrics(stream MetricObservation) returns (CollectResponse);
 }
 
 message CollectResponse {

--- a/sources/proto/volta.proto
+++ b/sources/proto/volta.proto
@@ -84,18 +84,26 @@ message DeviceID {
   }
 }
 
-message MetricObservation {
+// Describes the metrics that are sent within a batch
+message BatchHeader {
   MetricType metric_type = 1;
-  DeviceID device_id = 2;
-  google.protobuf.Timestamp timestamp = 3;
-  double value = 4;
+  optional DeviceID device_id = 2;
 }
 
+// The server sends these back to acknowledge a batch.
+message BatchAck {
+  uint64 samples_received = 1;
+  optional string error = 2;
+}
+
+// Batch multiple metrics into one message to keep the header overhead low
+message MetricBatch {
+  BatchHeader header = 1;
+  repeated uint64 timestamps_ns = 2 [packed = true];
+  repeated double values = 3 [packed = true];
+}
+
+// Unary calls over persistent channel
 service VoltaCollector {
-  rpc CollectMetrics(stream MetricObservation) returns (CollectResponse);
-}
-
-message CollectResponse {
-  bool success = 1;
-  string message = 2;
+  rpc StreamMetrics(MetricBatch) returns (BatchAck);
 }


### PR DESCRIPTION
This pull request introduces a new metrics buffering system and introduces a `DeviceID` tagging system. The main changes include implementing the `buffer.h`/`buffer.cc` system for efficient metrics storage and updating all collectors to use the new `DeviceID` type.

**Metrics Buffering System:**

* Added new `SeriesBuffer` and `MetricsBuffer` classes in `buffer.h`/`buffer.cc` to efficiently store and manage time-series metric samples, including thread-safe access and snapshotting. [[1]](diffhunk://#diff-926609b9e07ca4d5ef1edd6a092d358f76396c9bd2473ca8784339a7903e3b5fR1-R121) [[2]](diffhunk://#diff-6ea20ab80b92be5f69613582bc1b55a15cfd88f8130e4c46ca010a2115de360dR1-R194)
* The `MetricsBuffer` maps `MetricType` and `DeviceID` combination to a corresponding `SeriesBuffer`.
* The `SeriesBuffer` holds a ring buffer of `Sample`s as well as write and read markers. It enables pushing new samples, getting a snapshot of unread metrics and acking the snapshot to advance the read marker.

**`DeviceID` tagging**
* The `Metric` struct was updated to include a `deviceId` field that identifies the device that a measurement was performed on.
* Collectors were updated to detect hardware and measure the requested metrics on all avaliable devices.
* The combination of `MetricType` and `DeviceID` identifies metrics.

These changes enhance the flexibility, correctness, and maintainability of the agent's metrics collection and buffering infrastructure.