### PR TITLE
Feat/local mode fallback

### DIFF
--- a/sources/agent/src/main.cc
+++ b/sources/agent/src/main.cc
@@ -36,7 +36,7 @@ int main() {
         client::Client grpc_client(channel, config, buffer);
         grpc_client.Connect();
       } else {
-        std::cerr << "Failed to create gRPC channel, exiting" << std::endl;
+        std::cerr << "Failed to create gRPC channel, falling back to local dashboard" << std::endl;
         scheduler.print_dashboard.store(true);
       }
     });

--- a/sources/agent/src/main.cc
+++ b/sources/agent/src/main.cc
@@ -25,8 +25,6 @@ int main() {
     auto active_collectors = collectors::CollectorRegistry::Instance().Resolve(
         config.requestedMetrics);
 
-    std::cin.get();
-
     std::shared_ptr<MetricsBuffer> buffer =
         std::make_shared<MetricsBuffer>(config);
     Scheduler scheduler(config, std::move(active_collectors), buffer);
@@ -39,6 +37,7 @@ int main() {
         grpc_client.Connect();
       } else {
         std::cerr << "Failed to create gRPC channel, exiting" << std::endl;
+        scheduler.print_dashboard.store(true);
       }
     });
 

--- a/sources/agent/src/scheduler.cc
+++ b/sources/agent/src/scheduler.cc
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+#include <atomic>
 
 namespace volta {
 namespace agent {

--- a/sources/agent/src/scheduler.cc
+++ b/sources/agent/src/scheduler.cc
@@ -29,7 +29,7 @@ void Scheduler::Run() {
       buffer_->AddMetrics(metrics);
     }
 
-    // PrintDashboard();
+    if (print_dashboard.load()) PrintDashboard();
 
     std::this_thread::sleep_for(config_.collection_interval);
   }
@@ -59,7 +59,7 @@ void Scheduler::PrintDashboard() {
   std::cout << "\033[2J\033[1;1H";
 
   std::cout << "===============================================\n";
-  std::cout << "    VOLTA AGENT v0.5 - ACTIVE MONITOR    \n";
+  std::cout << "    VOLTA AGENT - ACTIVE MONITOR    \n";
   std::cout << "===============================================\n";
 
   std::cout << std::left << std::setw(42) << "METRIC NAME" << std::setw(38)

--- a/sources/agent/src/scheduler.h
+++ b/sources/agent/src/scheduler.h
@@ -21,6 +21,8 @@ class Scheduler {
 
   void Run();
 
+  std::atomic<bool> print_dashboard = false;
+
  private:
   void PrintDashboard();
   static std::string DescribeKey(const BufferKey& key);


### PR DESCRIPTION
# This pull request adds a fallback local dashboard to the agent.

Whenever opening a channel to the server fails, the scheduler::print_dashboard flag is set to true, enabling the local dashboard.