### PR TITLE
Restrict CORS to configured origins

### DIFF
--- a/sources/server/cmd/server/main.go
+++ b/sources/server/cmd/server/main.go
@@ -42,7 +42,7 @@ func main() {
 	registry := &registry.AgentRegistry{}
 	bus := eventbus.New()
 	router := commandrouter.New(registry)
-	hub := hub.New(bus)
+	hub := hub.New(bus, cfg.REST.AllowedOrigins)
 	go hub.Run()
 
 	// gRPC
@@ -60,7 +60,7 @@ func main() {
 	}()
 
 	// HTTP
-	httpSrv := httpserver.NewHTTPServer(registry, router, hub)
+	httpSrv := httpserver.NewHTTPServer(registry, router, hub, cfg.REST.AllowedOrigins)
 	srv := &http.Server{
 		Addr:         net.JoinHostPort(cfg.REST.Addr, strconv.Itoa(int(cfg.REST.Port))),
 		Handler:      httpSrv,

--- a/sources/server/internal/config/config.go
+++ b/sources/server/internal/config/config.go
@@ -50,7 +50,7 @@ type GRPCConfig struct {
 type RESTConfig struct {
 	Addr           string   `koanf:"addr"`
 	Port           uint16   `koanf:"port"`
-	AllowedOrigins []string `koanf:"allowed_origins"`
+	AllowedOrigins []string `koanf:"origins"`
 }
 
 type BufferConfig struct {
@@ -128,7 +128,7 @@ func Load() (*Config, error) {
 	f.Uint("grpc.port", GRPCPORT_DEFAULT, "")
 	f.String("rest.addr", ADDR_DEFAULT, "")
 	f.Uint("rest.port", RESTPORT_DEFAULT, "")
-	f.StringSlice("rest.allowed-origins", DefaultAllowedOrigins, "")
+	f.StringSlice("rest.origins", DefaultAllowedOrigins, "")
 	f.Uint("buf.size", BUFSIZE_DEFAULT, "")
 
 	if err := f.Parse(os.Args[1:]); err != nil {

--- a/sources/server/internal/config/config.go
+++ b/sources/server/internal/config/config.go
@@ -29,6 +29,12 @@ const (
 	ENV_CONF   = ".env"
 )
 
+var DefaultAllowedOrigins = []string{
+	"http://localhost:5173",
+	"http://127.0.0.1:5173",
+	"https://monvit.github.io",
+}
+
 type Config struct {
 	GRPC GRPCConfig   `koanf:"grpc"`
 	REST RESTConfig   `koanf:"rest"`
@@ -42,8 +48,9 @@ type GRPCConfig struct {
 }
 
 type RESTConfig struct {
-	Addr string `koanf:"addr"`
-	Port uint16 `koanf:"port"`
+	Addr           string   `koanf:"addr"`
+	Port           uint16   `koanf:"port"`
+	AllowedOrigins []string `koanf:"allowed_origins"`
 }
 
 type BufferConfig struct {
@@ -61,8 +68,9 @@ func Default() *Config {
 			Port: GRPCPORT_DEFAULT,
 		},
 		REST: RESTConfig{
-			Addr: ADDR_DEFAULT,
-			Port: RESTPORT_DEFAULT,
+			Addr:           ADDR_DEFAULT,
+			Port:           RESTPORT_DEFAULT,
+			AllowedOrigins: append([]string(nil), DefaultAllowedOrigins...),
 		},
 		Buf: BufferConfig{
 			Size: BUFSIZE_DEFAULT,
@@ -120,6 +128,7 @@ func Load() (*Config, error) {
 	f.Uint("grpc.port", GRPCPORT_DEFAULT, "")
 	f.String("rest.addr", ADDR_DEFAULT, "")
 	f.Uint("rest.port", RESTPORT_DEFAULT, "")
+	f.StringSlice("rest.allowed-origins", DefaultAllowedOrigins, "")
 	f.Uint("buf.size", BUFSIZE_DEFAULT, "")
 
 	if err := f.Parse(os.Args[1:]); err != nil {

--- a/sources/server/internal/httpserver/httpserver.go
+++ b/sources/server/internal/httpserver/httpserver.go
@@ -22,17 +22,24 @@ import (
 // ── HTTP Server ───────────────────────────────────────────────────────────────
 
 type HTTPServer struct {
-	registry *registry.AgentRegistry
-	router   *commandrouter.CommandRouter
-	hub      *hub.WSHub
-	mux      *chi.Mux
+	registry        *registry.AgentRegistry
+	router          *commandrouter.CommandRouter
+	hub             *hub.WSHub
+	allowedOrigins  []string
+	mux             *chi.Mux
 }
 
-func NewHTTPServer(registry *registry.AgentRegistry, router *commandrouter.CommandRouter, hub *hub.WSHub) *HTTPServer {
+func NewHTTPServer(
+	registry *registry.AgentRegistry,
+	router *commandrouter.CommandRouter,
+	hub *hub.WSHub,
+	allowedOrigins []string,
+) *HTTPServer {
 	s := &HTTPServer{
-		registry: registry,
-		router:   router,
-		hub:      hub,
+		registry:       registry,
+		router:         router,
+		hub:            hub,
+		allowedOrigins: allowedOrigins,
 	}
 	s.mux = s.routes()
 	return s
@@ -48,7 +55,7 @@ func (s *HTTPServer) routes() *chi.Mux {
 	mux.Use(middleware.RequestID)
 	mux.Use(middleware.RealIP)
 	mux.Use(middleware.Recoverer)
-	mux.Use(corsMiddleware)
+	mux.Use(corsMiddleware(s.allowedOrigins))
 	mux.Use(middleware.Timeout(30 * time.Second))
 
 	mux.Route("/api", func(r chi.Router) {
@@ -62,19 +69,50 @@ func (s *HTTPServer) routes() *chi.Mux {
 	return mux
 }
 
-func corsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept")
+func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
+	allowed := make(map[string]struct{}, len(allowedOrigins))
+	for _, origin := range allowedOrigins {
+		allowed[origin] = struct{}{}
+	}
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
+	isAllowed := func(origin string) bool {
+		if origin == "" {
+			return true
 		}
+		_, ok := allowed[origin]
+		return ok
+	}
 
-		next.ServeHTTP(w, r)
-	})
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if !isAllowed(origin) {
+				if r.Method == http.MethodOptions {
+					http.Error(w, "origin not allowed", http.StatusForbidden)
+					return
+				}
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Vary", "Origin")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept")
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────

--- a/sources/server/internal/httpserver/httpserver.go
+++ b/sources/server/internal/httpserver/httpserver.go
@@ -22,11 +22,11 @@ import (
 // ── HTTP Server ───────────────────────────────────────────────────────────────
 
 type HTTPServer struct {
-	registry        *registry.AgentRegistry
-	router          *commandrouter.CommandRouter
-	hub             *hub.WSHub
-	allowedOrigins  []string
-	mux             *chi.Mux
+	registry       *registry.AgentRegistry
+	router         *commandrouter.CommandRouter
+	hub            *hub.WSHub
+	allowedOrigins []string
+	mux            *chi.Mux
 }
 
 func NewHTTPServer(

--- a/sources/server/internal/hub/hub.go
+++ b/sources/server/internal/hub/hub.go
@@ -26,14 +26,24 @@ type WSHub struct {
 	mu       sync.Mutex
 }
 
-func New(bus *eventbus.EventBus) *WSHub {
+func New(bus *eventbus.EventBus, allowedOrigins []string) *WSHub {
+	allowed := make(map[string]struct{}, len(allowedOrigins))
+	for _, origin := range allowedOrigins {
+		allowed[origin] = struct{}{}
+	}
+
 	return &WSHub{
 		bus: bus,
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 			CheckOrigin: func(r *http.Request) bool {
-				return true
+				origin := r.Header.Get("Origin")
+				if origin == "" {
+					return true
+				}
+				_, ok := allowed[origin]
+				return ok
 			},
 		},
 		register: make(chan *WSClient, 16),


### PR DESCRIPTION
 ## Summary
Follow-up to #35: replace permissive `Access-Control-Allow-Origin: *` with a configurable origin allowlist for the REST API and WebSocket upgrades.
 
 - Adds `rest.origins` config
 - Default allowlist: Vite dev server (`localhost:5173`, `127.0.0.1:5173`) and GitHub Pages (`https://monvit.github.io`)
 - HTTP CORS echoes allowed origins; disallowed preflights return 403
 - WebSocket `CheckOrigin` uses the same list
 
Closes #36