### PR TITLE
Link collectors via OBJECT library so self-registration runs

### DIFF
--- a/sources/agent/CMakeLists.txt
+++ b/sources/agent/CMakeLists.txt
@@ -77,7 +77,9 @@ target_link_libraries(volta_proto PUBLIC
 file(GLOB_RECURSE AGENT_LIB_SOURCES CONFIGURE_DEPENDS "src/*.cc")
 list(FILTER AGENT_LIB_SOURCES EXCLUDE REGEX ".*/main\\.cc$")
 
-add_library(volta_lib STATIC)
+# OBJECT so collector self-registration always links in
+# see https://github.com/monvit/volta/issues/52
+add_library(volta_lib OBJECT)
 target_sources(volta_lib PRIVATE ${AGENT_LIB_SOURCES})
 
 target_compile_options(volta_lib PRIVATE -std=c++20)


### PR DESCRIPTION
## Summary

- Collector self-registration relies on static initializers in `RegisteredCollector<Derived>` (`src/collectors/collector.h`). Since #49 moved sources into `volta_lib` as a `STATIC` library and `main.cc` references no collector symbols, the linker discards the collector translation units - the registry is empty at runtime and the agent silently collects zero metrics.
- Build `volta_lib` as an `OBJECT` library so all collector objects are always linked.

Closes #52 