### PR TITLE
Use env shebang in pre-commit

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 BUILD_DIR="$REPO_ROOT/sources/agent/build"


### PR DESCRIPTION
## Summary

Use `#!/usr/bin/env bash` in the pre-commit hook so git can locate bash via `PATH` instead of relying on a hardcoded `/bin/bash` path.